### PR TITLE
Run workflow in a single step

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -2,9 +2,10 @@ use crate::builder::Builder;
 use crate::exit_with_error;
 use crate::query::Query;
 use crate::repository::Repository;
-use alfred::{Item, ItemBuilder};
+use alfred::{Item, ItemBuilder, ItemType};
 use clap::Values;
 use std::fs::read_to_string;
+use std::io::stdout;
 use std::process::exit;
 
 pub struct Build<'a> {
@@ -15,7 +16,8 @@ impl<'a> Build<'a> {
     pub fn item(query: &str) -> Item<'a> {
         ItemBuilder::new("Create .gitignore file")
             .subtitle("Combine the selected templates into a single .gitignore file")
-            .arg(format!("--build {}", query))
+            .autocomplete(format!("--build {}", query))
+            .valid(false)
             .into_item()
     }
 
@@ -34,8 +36,22 @@ impl<'a> Build<'a> {
             Ok(path) => path,
             Err(error) => exit_with_error(&error),
         };
+        let path_str = path.to_str().unwrap();
 
-        println!("{}", read_to_string(&path).unwrap());
+        alfred::json::write_items(
+            stdout(),
+            &[
+                ItemBuilder::new("Open .gitignore file")
+                    .arg(path_str)
+                    .type_(ItemType::File)
+                    .icon_file(path_str)
+                    .into_item(),
+                ItemBuilder::new("Copy to clipboard")
+                    .arg(read_to_string(&path).unwrap())
+                    .into_item(),
+            ],
+        )
+        .unwrap();
 
         exit(0);
     }

--- a/src/update.rs
+++ b/src/update.rs
@@ -12,7 +12,8 @@ impl<'a> Update<'a> {
     pub fn item() -> Item<'a> {
         ItemBuilder::new("Update .gitignore templates")
             .subtitle("Download the latest templates from github/gitignore")
-            .arg("--update")
+            .autocomplete("--update")
+            .valid(false)
             .into_item()
     }
 
@@ -22,7 +23,9 @@ impl<'a> Update<'a> {
                 alfred::json::write_items(
                     stdout(),
                     &[ItemBuilder::new("Successfully updated the templates")
-                        .subtitle("The latest templates from github/gitignore have been downloaded")
+                        .subtitle("Press Enter to start building a .gitignore file")
+                        .autocomplete("")
+                        .valid(false)
                         .into_item()],
                 )
                 .unwrap();


### PR DESCRIPTION
The output of the CLI has been adjusted to keep running everything in a
single step in Alfred. This makes it possible to implement the workflow
I had in mind originally.