### PR TITLE
Replace push_str when adding a single character

### DIFF
--- a/src/command/select.rs
+++ b/src/command/select.rs
@@ -32,7 +32,7 @@ impl<'a> Select<'a> {
 
         for suggestion in query.suggestions() {
             let mut autocomplete = query_string.clone();
-            autocomplete.push_str(" ");
+            autocomplete.push(' ');
             autocomplete.push_str(&suggestion);
 
             items.push(
@@ -60,7 +60,7 @@ impl<'a> Select<'a> {
                 .cloned()
                 .collect();
 
-            query_string.push_str(" ");
+            query_string.push(' ');
             query_string.push_str(&names.join(" "));
         }
 


### PR DESCRIPTION
Clippy recommends using `push` over `push_str` when adding a single
character, because it makes the intent clearer.