### PR TITLE
Remove needless borrow

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -40,7 +40,7 @@ impl Builder {
                 let content = read_to_string(template_path)?;
 
                 file.write_all(format!("### {}\n", template.file_name()).as_bytes())?;
-                file.write_all(&content.as_bytes())?;
+                file.write_all(content.as_bytes())?;
 
                 if i < self.templates.len() - 1 {
                     file.write_all(b"\n")?;


### PR DESCRIPTION
After upgrading Rust to 1.54.0, Clippy flagged a needless borrow in the
builder. The borrow has been removed to fix the lint.