### PR TITLE
Remove obsolete Clippy hint

### DIFF
--- a/src/repository.rs
+++ b/src/repository.rs
@@ -91,10 +91,6 @@ impl Repository {
             })
             .collect();
 
-        // Clippy throws a false negative here, probably caused by either of the two issues:
-        // - https://github.com/rust-lang/rust-clippy/issues/5754
-        // - https://github.com/rust-lang/rust-clippy/issues/6001
-        #[allow(clippy::unnecessary_sort_by)]
         templates.sort_by(|a, b| a.name().cmp(b.name()));
 
         Ok(templates)


### PR DESCRIPTION
In earlier versions of Rust, Clippy threw a warning about an apparently
unnecessary sort function. This was a false negative, and the lint was
disabled with a hint in the code. Since the bug has been fixed in a
recent version of Rust, the hint is being removed.