### PR TITLE
Install OpenSSL headers in GitHub Actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Install system dependenies
+        run: sudo apt-get install libssl-dev
+
       - name: Determine if files changed
         uses: fkirc/skip-duplicate-actions@v5.2.0
         id: skip_check


### PR DESCRIPTION
The current versions of the `rust-openssl` crate and Ubuntu require that the development headers for OpenSSL are installed on the machine.