### PR TITLE
Debug failing GitHub Actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,12 +16,12 @@ name: Rust
 jobs:
   lint:
     name: Lint
-    uses: jdno/workflows/.github/workflows/rust-lint.yml@main
+    uses: jdno/workflows/.github/workflows/rust-lint.yml@run-rust-docker
 
   style:
     name: Style
-    uses: jdno/workflows/.github/workflows/rust-style.yml@main
+    uses: jdno/workflows/.github/workflows/rust-style.yml@run-rust-docker
 
   test:
     name: Test
-    uses: jdno/workflows/.github/workflows/rust-test.yml@main
+    uses: jdno/workflows/.github/workflows/rust-test.yml@run-rust-docker


### PR DESCRIPTION
We are temporarily switching to a development branch of the GitHub Actions to fix build failures that we're seeing in open pull requests. The intention is to revert this commit once the problems have been fixed.