### PR TITLE
Switch to Flowcrafter-managed workflows

### DIFF
--- a/.github/flowcrafter.yml
+++ b/.github/flowcrafter.yml
@@ -1,0 +1,5 @@
+library:
+  github:
+    instance: https://api.github.com/
+    owner: jdno
+    repository: workflows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,14 @@ jobs:
     name: Publish crate
     runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v3
+    container:
+      image: ghcr.io/jdno/rust:main
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: publish
-          args: -v --all-features
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Publish crate
+        run: cargo publish -v --all-features
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,15 +44,15 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.any_changed == 'true'
 
+    container:
+      image: ghcr.io/jdno/rust:main
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
       - name: Cache build artifacts
         uses: swatinem/rust-cache@v2.5.0
-
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
 
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
@@ -64,12 +64,12 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.any_changed == 'true'
 
+    container:
+      image: ghcr.io/jdno/rust:main
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
 
       - name: Run Rustfmt
         run: cargo fmt --all -- --check

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -24,8 +24,8 @@ jobs:
         uses: tj-actions/changed-files@v37
         with:
           files: |
-            **/*.yml
             **/*.yaml
+            **/*.yml
 
       - name: Print changed files
         run: |


### PR DESCRIPTION
FlowCrafter[^1] is a command-line tool that makes it easy to create and update GitHub Actions workflows from a shared repository. It has been set up to pull from my personal collection, which is very similar to what was already configured in this repository. The most meaningful change is that Rust builds now run inside a pre-built container.

[^1]: https://github.com/jdno/flowcrafter