### PR TITLE
Update Rust workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -100,7 +100,7 @@ jobs:
             --timeout 120 \
             --target-dir target/tarpaulin-target/ \
             --skip-clean \
-            --out Xml
+            --out xml
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
tarpaulin, the tool to collect test coverage, has recently had a breaking change in its command-line arguments. The arguments have been updated to work with the most recent version.