### PR TITLE
Revert "Bump codecov/codecov-action from 3 to 4"

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -103,7 +103,7 @@ jobs:
             --out xml
 
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
The `v4` tag was published accidentally for a pre-release version, and was removed after we updated to it. This causes all builds to fail right now, since no version with that tag can be found.

This reverts commit beefe7b3354d451fd6f79b9a4fc1e36b226f794b.