### PR TITLE
Change engine for Tarpaulin

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -95,12 +95,13 @@ jobs:
       - name: Run tests with test coverage
         run: |
           cargo +nightly tarpaulin \
-            --verbose \
             --all-features \
-            --timeout 120 \
-            --target-dir target/tarpaulin-target/ \
+            --engine llvm \
+            --out xml \
             --skip-clean \
-            --out xml
+            --target-dir target/tarpaulin-target/ \
+            --timeout 120 \
+            --verbose
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
Tarpaulin uses Ptrace as its backend by default, but also supports an LLVM backend. We're opting into that backend to hopefully resolve a build failure that recently started appearing.