### PR TITLE
Measure test coverage on stable Rust

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,7 +82,7 @@ jobs:
     if: needs.detect-changes.outputs.any_changed == 'true'
 
     container:
-      image: xd009642/tarpaulin:develop-nightly
+      image: xd009642/tarpaulin:0.27.3-slim
       options: --security-opt seccomp=unconfined
 
     steps:
@@ -94,7 +94,7 @@ jobs:
 
       - name: Run tests with test coverage
         run: |
-          cargo +nightly tarpaulin \
+          cargo tarpaulin \
             --all-features \
             --engine llvm \
             --out xml \


### PR DESCRIPTION
Tarpaulin does not require a nightly compiler anymore, and by switching to the stable releases we increase the stability and reliability of the test suite.