### PR TITLE
Install system dependencies for Rust workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,6 +86,10 @@ jobs:
       options: --security-opt seccomp=unconfined
 
     steps:
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update && sudo apt-get install -y pkg-config
+
       - name: Checkout code
         uses: actions/checkout@v4
 


### PR DESCRIPTION
The Rust workflow started failing in #281 due to missing system-level dependencies in the container that is running the tests.